### PR TITLE
Add Storage Services APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 using Azure
 using Swagger
 using Azure.StorageManagementClient
+using Azure.StorageServices
 using Azure.ComputeManagementClient
 
 # create AzureCredentials with a service principal (tenant_id, appid, password)
@@ -33,4 +34,16 @@ osdiskname = get_field(vm_osdisk, "name")
 
 nics = get_field(vm, "properties", "networkProfile", "networkInterfaces")
 nicids = [rsplit(nicid, '/'; limit=2)[2] for nicid in map(nicref->get_field(nicref, "id"), nics)]
+
+# file share operations
+const resource_group_name = "testresgroup"
+const fileshare = "https://mystorage.file.core.windows.net/myshare?restype=share"
+success, resp = createShare(ctx, subscription_id, resource_group_name, fileshare, "100", Dict("testmetaname"=>"testmetaval"))
+success = setShareProperties(ctx, subscription_id, resource_group_name, fileshare, "150")
+success, properties = getShareProperties(ctx, subscription_id, resource_group_name, fileshare)
+deleteShare(ctx, subscription_id, resource_group_name, fileshare)
+
+# file blob operations
+const blob = "https://mystorage.blob.core.windows.net/testblob/myblob.dat"
+deleteBlob(ctx, subscription_id, resource_group_name, blob)
 ```

--- a/src/Azure.jl
+++ b/src/Azure.jl
@@ -155,6 +155,9 @@ _module_versions[PolicyClient] = "2016-12-01"
 _api_versions[PolicyClient.PolicyAssignmentsApi] = "2016-12-01"
 _api_versions[PolicyClient.PolicyDefinitionsApi] = "2016-12-01"
 
+# Storage services
+include("Storage/StorageServices/StorageServices.jl")
+
 # helper methods to assist in authentication, logging and such
 include("helper.jl")
 

--- a/src/Storage/StorageServices/StorageServices.jl
+++ b/src/Storage/StorageServices/StorageServices.jl
@@ -1,0 +1,14 @@
+module StorageServices
+
+using ..Azure
+using Azure.StorageManagementClient
+using Requests
+using MbedTLS
+using HttpCommon
+
+include("protocol.jl")
+include("common.jl")
+include("blob.jl")
+include("file.jl")
+
+end

--- a/src/Storage/StorageServices/blob.jl
+++ b/src/Storage/StorageServices/blob.jl
@@ -1,0 +1,3 @@
+deleteBlob(ctx, subscription_id::String, resource_group_name::String, diskuri::String; kwargs...) = deleteResource(ctx, subscription_id, resource_group_name, diskuri; kwargs...)
+
+export deleteBlob

--- a/src/Storage/StorageServices/common.jl
+++ b/src/Storage/StorageServices/common.jl
@@ -1,0 +1,7 @@
+function deleteResource(ctx, subscription_id::String, resource_group_name::String, diskuri::String; kwargs...)
+    storage_account, key = extract_account_and_key(ctx, subscription_id, resource_group_name, diskuri)
+
+    req = ServiceRequest(storage_account, "DELETE", diskuri)
+    resp = execute(req, key; kwargs...)
+    issuccess(resp)
+end

--- a/src/Storage/StorageServices/file.jl
+++ b/src/Storage/StorageServices/file.jl
@@ -1,0 +1,59 @@
+deleteShare(ctx, subscription_id::String, resource_group_name::String, diskuri::String; kwargs...) = deleteResource(ctx, subscription_id, resource_group_name, diskuri; kwargs...)
+
+function getShareProperties(ctx, subscription_id::String, resource_group_name::String, diskuri::String; kwargs...)
+    storage_account, key = extract_account_and_key(ctx, subscription_id, resource_group_name, diskuri)
+
+    req = ServiceRequest(storage_account, "GET", diskuri)
+    resp = execute(req, key; kwargs...)
+    success = issuccess(resp)
+
+    properties = Dict{String,String}()
+    if success
+        for (n,v) in resp.headers
+            if startswith(n, "x-ms-share") || startswith(n, "x-ms-meta")
+                properties[n] = v
+            end
+        end
+    end
+    success, properties
+end
+
+function createShare(ctx, subscription_id::String, resource_group_name::String, diskuri::String, quota::String="", metadata::Dict{String,String}=Dict{String,String}(); kwargs...)
+    storage_account, key = extract_account_and_key(ctx, subscription_id, resource_group_name, diskuri)
+
+    req = ServiceRequest(storage_account, "PUT", diskuri)
+    isempty(quota) || (req.headers["x-ms-share-quota"] = quota)
+    for (n,v) in metadata
+        startswith(n, "x-ms-") || (n = "x-ms-meta-"*n)
+        req.headers[n] = v
+    end
+    resp = execute(req, key; kwargs...)
+    issuccess(resp)
+end
+
+function setShareProperties(ctx, subscription_id::String, resource_group_name::String, diskuri::String, quota::String; kwargs...)
+    storage_account, key = extract_account_and_key(ctx, subscription_id, resource_group_name, diskuri)
+    parts = split(diskuri, "?"; limit=2)
+    diskuri = parts[1] * "?restype=share&comp=properties"
+
+    req = ServiceRequest(storage_account, "PUT", diskuri)
+    isempty(quota) || (req.headers["x-ms-share-quota"] = quota)
+    resp = execute(req, key; kwargs...)
+    issuccess(resp)
+end
+
+function setShareMetadata(ctx, subscription_id::String, resource_group_name::String, diskuri::String, metadata::Dict{String,String}; kwargs...)
+    storage_account, key = extract_account_and_key(ctx, subscription_id, resource_group_name, diskuri)
+    parts = split(diskuri, "?"; limit=2)
+    diskuri = parts[1] * "?restype=share&comp=metadata"
+
+    req = ServiceRequest(storage_account, "PUT", diskuri)
+    for (n,v) in metadata
+        startswith(n, "x-ms-") || (n = "x-ms-meta-"*n)
+        req.headers[n] = v
+    end
+    resp = execute(req, key; kwargs...)
+    issuccess(resp)
+end
+
+export deleteShare, getShareProperties, createShare, setShareProperties, setShareMetadata

--- a/src/Storage/StorageServices/protocol.jl
+++ b/src/Storage/StorageServices/protocol.jl
@@ -1,0 +1,133 @@
+const API_VER = "2016-05-31"
+
+type StandardHeaders
+    content_encoding::Union{String,Void}
+    content_language::Union{String,Void}
+    content_length::Union{String,Void}
+    content_md5::Union{String,Void}
+    content_type::Union{String,Void}
+    date::Union{String,Void}
+    if_modified_since::Union{String,Void}
+    if_match::Union{String,Void}
+    if_none_match::Union{String,Void}
+    if_unmodified_since::Union{String,Void}
+    range::Union{String,Void}
+end
+
+function StandardHeaders(; kwargs...)
+    obj = StandardHeaders(nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing, nothing)
+    for (n,v) in kwargs
+        setfield!(obj, n, v)
+    end
+    obj
+end
+
+immutable ServiceRequest
+    account::String
+    verb::String
+    resource::String
+    standard_headers::StandardHeaders
+    headers::Dict{String,String}
+
+    function ServiceRequest(account::String, verb::String, resource::String; headers...)
+        hdrdate = Dates.format(now(Dates.UTC), Dates.RFC1123Format)
+        endswith(hdrdate, "GMT") || (hdrdate *= " GMT")
+    
+        reqhdrs = Dict{String,String}("x-ms-date"=>hdrdate, "x-ms-version"=>API_VER)
+        stdhdrparams = Dict{Symbol,String}()
+        for (n,v) in headers
+            if (n in fieldnames(StandardHeaders))
+                stdhdrparams[n] = v
+                reqhdrs[to_http_header_name(n)] = v
+            else
+                reqhdrs[string(n)] = v
+            end
+        end
+        (verb == "PUT") && (reqhdrs["Content-Length"] = "0")
+        stdhdr = StandardHeaders(; stdhdrparams...)
+
+        new(account, verb, resource, stdhdr, reqhdrs)
+    end
+end
+
+to_http_header_name(n::Symbol) = join(map(ucfirst, split(string(n), '_')), '-')
+
+sign_strip(str::String) = replace(strip(str), "\n", " ")
+sign_hdr(nv::Pair{String,String}) = lowercase(sign_strip(nv[1])) * ":" * sign_strip(nv[2])
+sign_hdr(nv::Pair{AbstractString,AbstractString}) = sign_hdr(String(nv[1])=>String(nv[2]))
+
+function sign_sharedkey(req::ServiceRequest, key::String)
+    iob = IOBuffer()
+
+    println(iob, req.verb)
+
+    for n in fieldnames(StandardHeaders)
+        v = getfield(req.standard_headers, n)
+        # special case rule for Content-Length header in api version 2015-02-21 and later
+        (n == :content_length) && (v !== nothing) && !isempty(v) && (parse(Int, v) == 0) && (v = nothing)
+        println(iob, v === nothing ? "" : v)
+    end
+
+    x_ms_headers = sort(map(sign_hdr, collect(filter((n,v)->startswith(lowercase(strip(n)), "x-ms-"), req.headers))))
+    for v in x_ms_headers
+        println(iob, v)
+    end
+
+    print(iob, canonicalize_resource(req.account, req.resource))
+
+    signingstr = String(take!(iob))
+    hmacsign = base64encode(digest(MD_SHA256, signingstr, base64decode(key)))
+    req.headers["Authorization"] = "SharedKey $(req.account):$(hmacsign)"
+    nothing
+end
+
+function canonicalize_resource(storage_account::String, uri::String)
+    container = join(split(uri, "/")[4:end], "/")
+    query = ""
+
+    if contains(container, "?")
+        cparts = split(container, "?"; limit=2)
+        container = String(cparts[1])
+        query = String(cparts[2])
+    end
+
+    iob = IOBuffer()
+    print(iob, "/", storage_account, "/", container)
+    if !isempty(query)
+        qparts = sort(map(sign_hdr, collect(HttpCommon.parsequerystring(query))))
+        for q in qparts
+            print(iob, "\n", q)
+        end
+    end
+    String(take!(iob))
+end
+
+function execute(req::ServiceRequest, key::String; retry_count::Int=0, retry_interval::Int=60)
+    success = false
+    resp = Response()
+    count = 0
+    method = eval(Requests, Symbol(lowercase(req.verb)))
+    sign_sharedkey(req, key)
+    while !success && count <= retry_count
+        count += 1
+        (count == 1) || sleep(retry_interval)
+        resp = method(req.resource; headers = req.headers)
+        success = (200 <= statuscode(resp) <= 206)
+        success && (return resp)
+        warn("Storage service request failed. ", resp)
+    end
+    resp
+end
+
+function extract_account_and_key(ctx, subscription_id::String, resource_group_name::String, diskuri::String)
+    # find the storage account
+    storage_account = String(split(split(diskuri, "/")[3], '.'; limit=2)[1])
+    
+    # get keys for it
+    allkeys = storageAccountsListKeys(Azure.api(ctx, StorageAccountsApi), resource_group_name, storage_account, apiver(StorageAccountsApi), subscription_id)
+    key = get_field(get_field(allkeys, "keys")[1], "value")
+
+    storage_account, key
+end
+
+issuccess(resp::Response) = (200 <= statuscode(resp) <= 206)

--- a/src/helper.jl
+++ b/src/helper.jl
@@ -1,4 +1,4 @@
-const DEFAULT_URI = "https://management.azure.com/"
+const DEFAULT_URI = "https://management.azure.com"
 const AUTH_URI = "https://login.microsoftonline.com"
 const DEFAULT_TOKEN_EXPIRE = 5*60
 
@@ -45,7 +45,7 @@ function authenticate(ctx::AzureContext)
     data = Dict{String,String}(
         "client_id" => client_id(ctx.auth_provider),
         "client_secret" => client_secret(ctx.auth_provider),
-        "resource" => DEFAULT_URI,
+        "resource" => DEFAULT_URI*"/",  # must end with /
         "grant_type" => "client_credentials"
     )
 


### PR DESCRIPTION
fixes #1 

New sub module `Azure.StorageServices` has:
- the api protocol implementation
- api implementations that are immediately required:
    - create, update and delete azure file shares
    - delete blobs