### PR TITLE
added Azure SAS generation for blobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,11 @@ success = setShareProperties(ctx, subscription_id, resource_group_name, fileshar
 success, properties = getShareProperties(ctx, subscription_id, resource_group_name, fileshare)
 deleteShare(ctx, subscription_id, resource_group_name, fileshare)
 
-# file blob operations
+# SAS operations
 const blob = "https://mystorage.blob.core.windows.net/testblob/myblob.dat"
+appendSAS(ctx, subscription_id, resource_group_name, blob)
+
+# file blob operations
 deleteBlob(ctx, subscription_id, resource_group_name, blob)
 
 # rate card

--- a/src/Storage/StorageServices/StorageServices.jl
+++ b/src/Storage/StorageServices/StorageServices.jl
@@ -3,9 +3,14 @@ module StorageServices
 using ..Azure
 using Azure.StorageManagementClient
 using Azure.REST
+using HTTP
+using MbedTLS
+using Dates
+using Base64
 
 include("common.jl")
 include("blob.jl")
 include("file.jl")
+include("sas.jl")
 
 end

--- a/src/Storage/StorageServices/sas.jl
+++ b/src/Storage/StorageServices/sas.jl
@@ -1,0 +1,105 @@
+struct EnumSASPermission
+    READ::String
+    ADD::String
+    CREATE::String
+    WRITE::String
+    DELETE::String
+    LIST::String
+    PROCESS::String
+end
+
+const SASPermission = EnumSASPermission("r", "a", "c", "w", "d", "l", "p")
+
+sas_permissions(perms...) = join(perms)
+
+const SAS_VERSION = "2017-11-09"
+
+sas_date_format(d::DateTime) = Dates.format(d, DateFormat("yyyy-mm-dd\\THH:MM:SS")) * "Z" #*"UTC"
+
+sas_canonicalize(raw_url::String) = sas_canonicalize(HTTP.URI(raw_url))
+function sas_canonicalize(url::HTTP.URI)
+    urlparts = split(url.host, ".")
+    accountname = String(urlparts[1])
+    restype = String(urlparts[2])
+    respath = url.path[2:end]
+
+    canonicalized_url = "/" * joinpath(restype, accountname, respath)
+    canonicalized_url, accountname, restype
+end
+
+sas_filename(raw_url::String) = basename(HTTP.URI(raw_url).path)
+sas_content_disposition(raw_url::String) = "attachment; filename=" * sas_filename(raw_url)
+
+function appendSAS(ctx, subscription_id::String, resource_group_name::String, raw_url::String; kwargs...)
+    account, key = extract_account_and_key(ctx, subscription_id, resource_group_name, raw_url)
+    appendSAS(raw_url, key; kwargs...)
+end
+
+function appendSAS(raw_url::String, key::String; permissions::String=SASPermission.READ,
+        start::Union{Nothing,DateTime}=nothing, expiry_hours::Int=24, expiry::Union{Nothing,DateTime}=nothing,
+        identifier::String="", ip::String="",
+        cache_control::String="no-cache, no-store, max-age=0",
+        content_disposition::String=sas_content_disposition(raw_url),
+        content_encoding::String="",
+        content_language::String="",
+        content_type::String="application/octet-stream")
+    url = HTTP.URI(raw_url)
+    canonicalized_url, accountname, restype = sas_canonicalize(url)
+
+    if restype == "blob"
+        sr = "b"
+    else
+        error("Not implemented yet for resources of type $restype")
+    end
+
+    if start === nothing
+        st = ""
+        start = Dates.now(Dates.UTC)
+    else
+        st = sas_date_format(start)
+    end
+    
+    if expiry === nothing
+        se = sas_date_format(start + Dates.Hour(expiry_hours))
+    else
+        se = sas_date_format(expiry)
+    end
+
+
+    str_to_sign = join([
+                        permissions, st, se,
+                        canonicalized_url,
+                        identifier,
+                        ip,
+                        url.scheme,
+                        SAS_VERSION,
+                        cache_control,
+                        content_disposition,
+                        content_encoding,
+                        content_language,
+                        content_type
+                    ], "\n")
+    sig = base64encode(digest(MD_SHA256, str_to_sign, base64decode(key)))
+
+    query_params =  [
+                        "sv"=>SAS_VERSION,
+                        "st"=>st,
+                        "se"=>se,
+                        "sr"=>sr,
+                        "si"=>identifier,
+                        "sp"=>permissions,
+                        "sip"=>ip,
+                        "spr"=>url.scheme,
+                        "sig"=>sig,
+                        "rscc"=>cache_control,
+                        "rscd"=>content_disposition,
+                        "rsce"=>content_encoding,
+                        "rscl"=>content_language,
+                        "rsct"=>content_type
+                    ]
+    filter!(kv->!isempty(kv[2]), query_params)
+    query_string = join(map((kv)->kv[1]*"="*HTTP.URIs.escapeuri(kv[2]), query_params), "&")
+    raw_url * "?" * query_string
+end
+
+export SASPermission, appendSAS

--- a/src/rest_api_protocol.jl
+++ b/src/rest_api_protocol.jl
@@ -7,7 +7,7 @@ using Base64
 
 const API_VER = "2016-05-31"
 
-const DEFAULT_CLIENT = HTTP.Client(; retries=0, readtimeout=300, status_exception=false)
+const DEFAULT_KWARGS = Dict(:retries=>0, :readtimeout=>300, :status_exception=>false)
 
 mutable struct StandardHeaders
     content_encoding::Union{String,Nothing}
@@ -114,7 +114,7 @@ function execute(req::ServiceRequest, key::String; retry_count::Int=0, retry_int
     while !success && count <= retry_count
         count += 1
         (count == 1) || sleep(retry_interval)
-        resp = HTTP.request(DEFAULT_CLIENT, uppercase(req.verb), HTTP.URIs.URI(req.resource); headers=req.headers)
+        resp = HTTP.request(uppercase(req.verb), HTTP.URIs.URI(req.resource), req.headers; DEFAULT_KWARGS...)
         success = (200 <= resp.status <= 206)
         success && (return resp)
         @warn("Storage service request failed. ", resp)


### PR DESCRIPTION
Added Azure SAS URL generation to allow blob downloads without sharing credentials.

**Enums:**
- SASPermission
    - READ
    - ADD
    - CREATE
    - WRITE
    - DELETE
    - LIST
    - PROCESS

**APIs**:
```
# returns concatenated permissions when more than one permission flags are desired
sas_permissions(perms...)
```

```
# returns raw_url appended with SAS signatures and parameters,
# signed with the supplied key
appendSAS(raw_url::String, key::String;
    permissions::String=SASPermission.READ, # one of more permissions from SASPermission
    start::Union{Nothing,DateTime}=nothing, # taken as current time if unspecified
    exphrs::Int=24, # used if expiry is unspecified
    expiry::Union{Nothing,DateTime}=nothing, # derived from start & exphrs if unspecified
    identifier::String="",
    ip::String="",
    cache_control::String="no-cache, no-store, max-age=0",
    content_disposition::String=sas_content_disposition(raw_url),
    content_encoding::String="",
    content_language::String="",
    content_type::String="application/octet-stream")
```
and

```
# returns raw_url appended with SAS signatures and parameters,
# signed with a key of the storage container in resource_group_name pointed to by raw_url
appendSAS(ctx::AzureContext,
    subscription_id::String,
    resource_group_name::String,
    raw_url::String;
    kwargs...)
```
where `kwargs` are the same as the first API.

Ref: https://docs.microsoft.com/en-us/azure/storage/common/storage-dotnet-shared-access-signature-part-1

Also updated `HTTP.request` usage for recent changes (`HTTP.Client` removed from HTTP.jl)