### PR TITLE
add more blob API implementaions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,10 +12,12 @@ JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 MbedTLS = "739be429-bea8-5141-9913-cc70e7f3736d"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Swagger = "2d69052b-6a58-5cd9-a030-a48559c324ac"
+XMLDict = "228000da-037f-5747-90a9-8195ccbf91a5"
 
 [compat]
 HTTP = "0.8"
 Swagger = "0.2"
+XMLDict = "0.3, 0.4"
 julia = "1"
 
 [extras]

--- a/README.md
+++ b/README.md
@@ -20,8 +20,11 @@ using Azure.UsageManagementClient
  It can be created from Azure portal UI, or from `az` command line. e.g.:
 
 ### command:
+
 `  az ad sp create-for-rbac --role="Owner" --scopes="/subscriptions/subscrip-tion-idxx-xxxx-xxxxxxxxxxxx" `
+
 ### result:
+
 ```
     {
       "appId": "appidxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
@@ -33,15 +36,18 @@ using Azure.UsageManagementClient
 ```
 
 ## Create AzureCredentials with a service principal (tenant_id, appid, password)
+
 ```
 creds = AzureCredentials("tenantid-xxxx-xxxx-xxxx-xxxxxxxxxxxx", 
                          "appidxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx", 
                          "password-xxxx-xxxx-xxxx-xxxxxxxxxxxx")
 ctx = AzureContext(creds)
 ```
+
 # Call APIs
 
 ## List operations
+
 ```
 StorageManagementClient.operationsList(api(ctx, OperationsApi), apiver(OperationsApi))
 
@@ -49,6 +55,7 @@ ComputeManagementClient.operationsList(api(ctx, ComputeOperationsApi), apiver(Co
 ```
 
 ## Get a VM and list out some of its attributes
+
 ```
 const subscription_id = "subscrip-tion-idxx-xxxx-xxxxxxxxxxxx"
 vm = virtualMachinesGet(api(ctx, VirtualMachinesApi), 
@@ -65,7 +72,9 @@ osdiskname = vm_osdisk.name
 nics = vm.properties.networkProfile.networkInterfaces
 nicids = [rsplit(nicid, '/'; limit=2)[2] for nicid in map(nicref->nicref.id, nics)]
 ```
+
 ## File share operations
+
 ```
 const resource_group_name = "testresgroup"
 const fileshare = "https://mystorage.file.core.windows.net/myshare?restype=share"
@@ -74,17 +83,51 @@ success = setShareProperties(ctx, subscription_id, resource_group_name, fileshar
 success, properties = getShareProperties(ctx, subscription_id, resource_group_name, fileshare)
 deleteShare(ctx, subscription_id, resource_group_name, fileshare)
 ```
+
 ## SAS operations
+
 ```
 const blob = "https://mystorage.blob.core.windows.net/testblob/myblob.dat"
 appendSAS(ctx, subscription_id, resource_group_name, blob)
 ```
+
 ## File blob operations
+
 ```
+const storageaccount_url = "https://mystorage.blob.core.windows.net/"
+const testcontainer = storageaccount_url * "testcontainer1"
+
+createContainer(ctx, subscription_id, resource_group_name, testcontainer)
+
+listContainers(ctx, subscription_id, resource_group_name, storageaccount_url)
+
+# create blob from string or bytes data
+putBlob(ctx, subscription_id, resource_group_name, blob, "BlockBlob";
+        block_blob_contents="hello world")
+
+# create blob from a disk file
+open(path) do io
+   @test putBlob(ctx, subscription_id, resource_group_name, blob, "BlockBlob";
+                block_blob_contents=io,
+                content_length=filesize(io))
+end
+
+listBlobs(ctx, subscription_id, resource_group_name, testcontainer)
+
+getBlob(ctx, subscription_id, resource_group_name, blob)
+
 deleteBlob(ctx, subscription_id, resource_group_name, blob)
 ```
+
+More examples [test/test_blobs.jl](here).
+
 ## Rate card
+
 ```
-ratefilter = "OfferDurableId eq 'MS-AZR-0003p' and Currency eq 'USD' and Locale eq 'en-US' and RegionInfo eq 'US'"
+ratefilter = join(["OfferDurableId eq 'MS-AZR-0003p'",
+                   "Currency eq 'USD'",
+                   "Locale eq 'en-US'",
+                   "RegionInfo eq 'US'"],
+                   " and ")
 rates = rateCardGet(api(ctx, RateCardApi), ratefilter, apiver(RateCardApi), subscription_id)
 ```

--- a/src/StorageServices/StorageServices.jl
+++ b/src/StorageServices/StorageServices.jl
@@ -3,6 +3,7 @@ module StorageServices
 using ..Azure
 using Azure.StorageManagementClient
 using Azure.REST
+using Azure.REST: AccountKey, service_response, parse_service_response, issuccess
 using HTTP
 using MbedTLS
 using Dates

--- a/src/StorageServices/blob.jl
+++ b/src/StorageServices/blob.jl
@@ -1,3 +1,243 @@
-deleteBlob(ctx, subscription_id::String, resource_group_name::String, diskuri::String; kwargs...) = deleteResource(ctx, subscription_id, resource_group_name, diskuri; kwargs...)
+"""
+Returns a list of the containers under the specified storage account.
 
-export deleteBlob
+Keyword arguments:
+- prefix: Optional. Filters the results to return only containers whose name begins with the specified prefix.
+- marker: Optional. A string value that identifies the portion of the list of containers to be returned with the next listing operation. The operation returns the NextMarker value within the response body if the listing operation did not return all containers remaining to be listed with the current page. The NextMarker value can be used as the value for the marker parameter in a subsequent call to request the next page of list items. The marker value is opaque to the client.
+- maxresults: Optional. Specifies the maximum number of containers to return. If the request does not specify maxresults, or specifies a value greater than 5000, the server will return up to 5000 items. Note that if the listing operation crosses a partition boundary, then the service will return a continuation token for retrieving the remainder of the results. For this reason, it is possible that the service will return fewer results than specified by maxresults, or than the default of 5000. If the parameter is set to a value less than or equal to zero, the server returns status code 400 (Bad Request).
+- includemetadata: Optional. Set to true to specify that the container's metadata be returned as part of the response body. Note that metadata requested with this parameter must be stored in accordance with the naming restrictions imposed by the 2009-09-19 version of the Blob service. Beginning with this version, all metadata names must adhere to the naming conventions for C# identifiers.
+- timeout: Optional. The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
+
+Returns a dictionary with response values.
+"""
+function listContainers(ctx, subscription_id::String, resource_group_name::String, uri::String, accountkey::Union{Nothing,AccountKey}=nothing; prefix=nothing, marker=nothing, maxresults=nothing, includemetadata=false, timeout=nothing, kwargs...)
+    include = includemetadata ? "metadata" : nothing
+    uri = append_params(uri; comp="list", prefix=prefix, marker=marker, maxresults=maxresults, include=include, timeout=timeout)
+    resp = getResource(ctx, subscription_id, resource_group_name, uri, accountkey; kwargs...)
+    parse_service_response(resp)
+end
+
+"""
+Creates a new container under the specified account. If the container with the same name already exists, the operation fails.
+
+Keyword arguments:
+- metadata: Optional. A dictionary with name-value pairs to associate with the container as metadata.
+- public_access: Optional. Specifies whether data in the container may be accessed publicly and the level of access. Possible values include:
+    - "container": Specifies full public read access for container and blob data. Clients can enumerate blobs within the container via anonymous request, but cannot enumerate containers within the storage account.
+    - "blob": Specifies public read access for blobs. Blob data within this container can be read via anonymous request, but container data is not available. Clients cannot enumerate blobs within the container via anonymous request.
+    - nothing: container data is private to the account owner.
+- timeout: Optional. The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
+
+Returns boolean indicating success or failure.
+"""
+function createContainer(ctx, subscription_id::String, resource_group_name::String, uri::String, accountkey::Union{Nothing,AccountKey}=nothing;
+        metadata::Union{Dict{String,String},Nothing}=nothing,
+        public_access::Union{String,Nothing}=nothing,
+        timeout=nothing,
+        kwargs...)
+
+    headers = Dict{Symbol,String}()
+
+    if public_access !== nothing
+        @assert public_access in ("container", "blob")
+        headers[Symbol("x-ms-blob-public-access")] = public_access
+    end
+
+    if metadata !== nothing
+        for (meta_name,meta_val) in metadata
+            headers[Symbol("x-ms-meta-"*meta_name)] = meta_val
+        end
+    end
+
+    uri = append_params(uri; restype="container", timeout=timeout)
+    resp = putResource(ctx, subscription_id, resource_group_name, uri, accountkey, headers; kwargs...)
+    issuccess(resp)
+end
+
+"""
+Marks the specified container for deletion. The container and any blobs contained within it are later deleted during garbage collection.
+
+Keyword arguments:
+- timeout: Optional. The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
+
+Returns boolean indicating success or failure.
+"""
+function deleteContainer(ctx, subscription_id::String, resource_group_name::String, uri::String, accountkey::Union{Nothing,AccountKey}=nothing; timeout=nothing, kwargs...)
+    uri = append_params(uri; restype="container", timeout=timeout)
+    resp = deleteResource(ctx, subscription_id, resource_group_name, uri, accountkey; kwargs...)
+    issuccess(resp)
+end
+
+const valid_list_blobs_include_data = ("snapshots", "metadata", "uncommittedblobs", "copy", "deleted", "versions")
+"""
+Returns a list of the blobs under the specified container.
+
+Keyword arguments:
+- prefix: Optional. Filters the results to return only blobs whose names begin with the specified prefix.
+- maxresults: Optional. Specifies the maximum number of blobs to return, including all BlobPrefix elements. If the request does not specify maxresults or specifies a value greater than 5,000, the server will return up to 5,000 items.  Setting maxresults to a value less than or equal to zero results in error response code 400 (Bad Request).
+- include_data: Optional. Specifies one or more datasets to include in the response:
+    - snapshots: Specifies that snapshots should be included in the enumeration. Snapshots are listed from oldest to newest in the response.
+    - metadata: Specifies that blob metadata be returned in the response.
+    - uncommittedblobs: Specifies that blobs for which blocks have been uploaded, but which have not been committed using Put Block List, be included in the response.
+    - copy: Version 2012-02-12 and newer. Specifies that metadata related to any current or previous Copy Blob operation should be included in the response.
+    - deleted: Version 2017-07-29 and newer. Specifies that soft deleted blobs should be included in the response.
+    - versions: Version 2019-12-12 and newer. Specifies that Versions of blobs should be included in the enumeration.
+- timeout: Optional. The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
+"""
+function listBlobs(ctx, subscription_id::String, resource_group_name::String, uri::String, accountkey::Union{Nothing,AccountKey}=nothing;
+        prefix::Union{String,Nothing}=nothing,
+        maxresults::Union{Int,Nothing}=nothing,
+        include_data=nothing,
+        timeout=nothing,
+        kwargs...)
+    include_data_repr = nothing
+    if include_data !== nothing
+        include_data_parts = Set{String}()
+        for part in include_data
+            partstr = string(part)
+            @assert partstr in valid_list_blobs_include_data
+            push!(include_data_parts, partstr)
+        end 
+        include_data_repr = HTTP.URIs.escapeuri(join(include_data_parts, ","))
+    end
+    uri = append_params(uri; restype="container", comp="list", prefix=prefix, maxresults=maxresults, include_data=include_data_repr, timeout=timeout)
+    resp = getResource(ctx, subscription_id, resource_group_name, uri, accountkey; kwargs...)
+    parse_service_response(resp)
+end
+
+const valid_blob_types = ("BlockBlob", "PageBlob", "AppendBlob")
+
+"""
+Creates a new block, page, or append blob, or updates the content of an existing block blob.
+
+Updating an existing block blob overwrites any existing metadata on the blob. Partial updates are not supported with Put Blob; the content of the existing blob is overwritten with the content of the new blob. To perform a partial update of the content of a block blob, use the Put Block List operation.
+
+A call to a Put Blob to create a page blob or an append blob only initializes the blob. To add content to a page blob, call the Put Page operation. To add content to an append blob, call the Append Block operation.
+
+`blob_type` can be one of "BlockBlob", "PageBlob", "AppendBlob"
+
+Keyword arguments:
+- metadata: Optional. A dictionary with name-value pairs to associate with the blob as metadata.
+- block_blob_contents. Required only for block blobs. Can be a string, bytearray or io stream that can be passed to HTTP library for streaming.
+- page_blob_max_size: Required for page blobs. This header specifies the maximum size for the page blob, up to 8 TB. The page blob size must be aligned to a 512-byte boundary.
+- access_tier: Version 2017-04-17 and newer. For page blobs on a premium storage account only. Specifies the tier to be set on the blob. Check High-performance Premium Storage and managed disks for VMs for a full list of supported tiers. For block blobs, supported on blob storage or general purpose v2 accounts only with version 2018-11-09 and newer. Valid values for block blob tiers are Hot/Cool/Archive. For detailed information about block blob tiering see Hot, cool and archive storage tiers.
+- timeout:	Optional. The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
+- content_length: must be set for a block blob if the block_blob_content is a stream
+- content_type: Optional. The MIME content type of the blob. The default type is application/octet-stream.
+"""
+function putBlob(ctx, subscription_id::String, resource_group_name::String, uri::String, blob_type::String, accountkey::Union{Nothing,AccountKey}=nothing;
+        metadata::Union{Dict{String,String},Nothing}=nothing,
+        block_blob_contents=nothing,
+        page_blob_max_size::Union{Int,Nothing}=nothing,
+        access_tier::Union{String,Nothing}=nothing,
+        timeout=nothing,
+        content_length::Union{Int,Nothing}=nothing,
+        content_type::Union{String,Nothing}=nothing,
+        kwargs...)
+
+    @assert blob_type in valid_blob_types
+    headers = Dict{Symbol,String}(
+        Symbol("x-ms-blob-type") => blob_type
+    )
+
+    if blob_type == "PageBlob"
+        @assert page_blob_max_size !== nothing
+        headers[Symbol("x-ms-blob-content-length")] = string(page_blob_max_size)
+    else
+        @assert page_blob_max_size === nothing
+    end
+
+    if access_tier !== nothing
+        headers[Symbol("x-ms-access-tier")] = access_tier
+    end
+
+    if metadata !== nothing
+        for (meta_name,meta_val) in metadata
+            headers[Symbol("x-ms-meta-"*meta_name)] = meta_val
+        end
+    end
+
+    if blob_type == "BlockBlob"
+        if block_blob_contents !== nothing
+            if content_length === nothing
+                if isa(block_blob_contents, String)
+                    content_length = length(codeunits(block_blob_contents))
+                elseif isa(block_blob_contents, Vector{Vector{String}})
+                    content_length = sum(length.(codeunits.(block_blob_contents)))
+                elseif isa(block_blob_contents, Vector{UInt8})
+                    content_length = length(block_blob_contents)
+                elseif isa(block_blob_contents, Vector{Vector{UInt8}})
+                    content_length = sum(length.(block_blob_contents))
+                else
+                    error("content_length must be specified for blob contents of type $(typeof(block_blob_contents))")
+                end
+            end
+        end
+    else
+        content_length = 0
+    end
+    headers[:content_length] = string(content_length)
+
+    if content_type !== nothing
+        headers[:content_type] = content_type
+        headers[Symbol("x-ms-blob-content-type")] = content_type
+    end
+
+    uri = append_params(uri; timeout=timeout)
+    #@debug("calling putResource", uri, headers, block_blob_contents)
+    resp = putResource(ctx, subscription_id, resource_group_name, uri, accountkey, headers, block_blob_contents; kwargs...)
+    issuccess(resp)
+end
+
+"""
+Reads or downloads a blob from the system, including its metadata and properties. You can also call Get Blob to read a snapshot.
+Returns the data bytes on success.
+
+Keyword arguments:
+- range: Optional. The range of bytes to get. A single number is treated as start byte and the remaining bytes are fetched.
+- snapshot: Optional. The snapshot parameter is an opaque DateTime value that, when present, specifies the blob snapshot to retrieve. For more information on working with blob snapshots, see Creating a Snapshot of a Blob.
+- versionid: Optional, version 2019-12-12 and newer. The versionid parameter is an opaque DateTime value that, when present, specifies the Version of the blob to retrieve.
+- timeout: Optional. The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
+"""
+function getBlob(ctx, subscription_id::String, resource_group_name::String, uri::String, accountkey::Union{Nothing,AccountKey}=nothing;
+        range::Union{Int,UnitRange{Int},Nothing}=nothing,
+        snapshot=nothing,
+        versionid=nothing,
+        timeout=nothing,
+        kwargs...)
+    headers = Dict{Symbol,String}()
+    if range !== nothing
+        if isa(range,Int)
+            rangestr = string(range) * "-"
+        else
+            rangestr = string(first(range)) * "-" * string(last(range))
+        end
+
+        headers[:range] = headers[Symbol("x-ms-range")] = rangestr
+    end
+    uri = append_params(uri; snapshot=snapshot, versionid=versionid, timeout=timeout)
+    resp = getResource(ctx, subscription_id, resource_group_name, uri, accountkey, headers; kwargs...)
+    service_response(resp)
+end
+
+"""
+Marks the specified blob or snapshot for deletion. The blob is later deleted during garbage collection.
+
+Keyword arguments:
+- snapshot:	Optional. The snapshot parameter is an opaque DateTime value that, when present, specifies the blob snapshot to delete. For more information on working with blob snapshots, see Creating a Snapshot of a Blob.
+- versionid:	Optional, version 2019-12-12 and newer. The versionid parameter is an opaque DateTime value that, when present, specifies the Version of the blob to delete.
+- timeout:	Optional. The timeout parameter is expressed in seconds. For more information, see Setting Timeouts for Blob Service Operations.
+
+Returns boolean indicating success or failure.
+"""
+function deleteBlob(ctx, subscription_id::String, resource_group_name::String, uri::String, accountkey::Union{Nothing,AccountKey}=nothing;
+        snapshot=nothing,
+        versionid=nothing,
+        timeout=nothing,
+        kwargs...)
+    uri = append_params(uri; snapshot=snapshot, versionid=versionid, timeout=timeout)
+    resp = deleteResource(ctx, subscription_id, resource_group_name, uri, accountkey; kwargs...)
+    issuccess(resp)
+end
+
+export deleteBlob, listContainers, createContainer, deleteContainer, listBlobs, putBlob, getBlob

--- a/src/StorageServices/common.jl
+++ b/src/StorageServices/common.jl
@@ -1,18 +1,56 @@
-function deleteResource(ctx, subscription_id::String, resource_group_name::String, diskuri::String; kwargs...)
-    storage_account, key = extract_account_and_key(ctx, subscription_id, resource_group_name, diskuri)
-
-    req = Azure.REST.ServiceRequest(storage_account, "DELETE", diskuri)
-    resp = Azure.REST.execute(req, key; kwargs...)
-    Azure.REST.issuccess(resp)
+function optionsResource(ctx, subscription_id::String, resource_group_name::String, uri::String, accountkey::Union{Nothing,AccountKey}=nothing, headers::Dict{Symbol,String}=Dict{Symbol,String}(); kwargs...)
+    resource_op(ctx, "OPTIONS", subscription_id, resource_group_name, uri, accountkey, headers; kwargs...)
 end
 
-function extract_account_and_key(ctx, subscription_id::String, resource_group_name::String, diskuri::String)
+function putResource(ctx, subscription_id::String, resource_group_name::String, uri::String, accountkey::Union{Nothing,AccountKey}=nothing, headers::Dict{Symbol,String}=Dict{Symbol,String}(), data=nothing; kwargs...)
+    resource_op(ctx, "PUT", subscription_id, resource_group_name, uri, accountkey, headers, data; kwargs...)
+end
+
+function getResource(ctx, subscription_id::String, resource_group_name::String, uri::String, accountkey::Union{Nothing,AccountKey}=nothing, headers::Dict{Symbol,String}=Dict{Symbol,String}(); kwargs...)
+    resource_op(ctx, "GET", subscription_id, resource_group_name, uri, accountkey, headers; kwargs...)
+end
+
+function deleteResource(ctx, subscription_id::String, resource_group_name::String, uri::String, accountkey::Union{Nothing,AccountKey}=nothing, headers::Dict{Symbol,String}=Dict{Symbol,String}(); kwargs...)
+    resource_op(ctx, "DELETE", subscription_id, resource_group_name, uri, accountkey, headers; kwargs...)
+end
+
+function resource_op(ctx, op::String, subscription_id::String, resource_group_name::String, uri::String, accountkey::Union{Nothing,AccountKey}, headers::Dict{Symbol,String}, data=nothing; kwargs...)
+    if accountkey === nothing
+        accountkey = extract_account_and_key(ctx, subscription_id, resource_group_name, uri)
+    end
+    req = Azure.REST.ServiceRequest(accountkey.account, op, uri, data; headers...)
+    Azure.REST.execute(req, accountkey.key; kwargs...)
+end
+
+function extract_account_and_key(ctx, subscription_id::String, resource_group_name::String, uri::String)
     # find the storage account
-    storage_account = String(split(split(diskuri, "/")[3], '.'; limit=2)[1])
+    account = String(split(split(uri, "/")[3], '.'; limit=2)[1])
 
     # get keys for it
-    allkeys = storageAccountsListKeys(Azure.api(ctx, StorageAccountsApi), resource_group_name, storage_account, apiver(StorageAccountsApi), subscription_id)
+    allkeys = storageAccountsListKeys(Azure.api(ctx, StorageAccountsApi), resource_group_name, account, apiver(StorageAccountsApi), subscription_id)
     key = (allkeys.keys[1]).value
 
-    storage_account, key
+    AccountKey(account, key)
+end
+
+function append_params(uristr::String; kwargs...)
+    haskwargs = false
+    for (k,v) in kwargs
+        if v !== nothing
+            haskwargs = true
+            break
+        end
+    end
+
+    if haskwargs
+        uri = HTTP.URIs.parse_uri(uristr)
+        query = HTTP.URIs.queryparams(uri)
+        for (k,v) in kwargs
+            (v !== nothing) && (query[string(k)] = string(v))
+        end
+        uri = merge(uri; query=query)
+        uristr = string(uri)
+    end
+
+    uristr
 end

--- a/test/test_blobs.jl
+++ b/test/test_blobs.jl
@@ -1,0 +1,69 @@
+using Azure
+using Azure.StorageServices
+using Test
+
+function test_blobs(tenant_id, appid, password, subscription_id, resource_group_name, storage)
+    creds = AzureCredentials(tenant_id, appid, password)
+    ctx = AzureContext(creds)
+
+    resource_group_name = "testresgroup"
+    testcontainer = storage * "testcontainer"
+    testblob1 = testcontainer * "/testblob1"
+    testblob2 = testcontainer * "/testblob2"
+
+    @test createContainer(ctx, subscription_id, resource_group_name, testcontainer)
+
+    result = listContainers(ctx, subscription_id, resource_group_name, storage)
+    @test haskey(result, "Containers")
+    @test haskey(result["Containers"], "Container")
+    containers = result["Containers"]["Container"]
+
+    container = containers
+    if isa(containers, Vector)
+        # iterate through multiple containers
+        for c in containers
+            if c["Name"] == "testcontainer"
+                container = c
+            end
+        end
+    end
+
+    @test haskey(container, "Name")
+    @test container["Name"] == "testcontainer"
+
+    # add a string as a blob
+    @test putBlob(ctx, subscription_id, resource_group_name, testblob1, "BlockBlob"; block_blob_contents="hello world")
+
+    # streaming a file as a blob
+    mktemp() do path, wio
+        println(wio, "hello world")
+        close(wio)
+        open(path) do rio
+           @test putBlob(ctx, subscription_id, resource_group_name, testblob2, "BlockBlob"; block_blob_contents=rio, content_length=filesize(rio))
+        end
+    end
+
+    # read blobs
+    result = listBlobs(ctx, subscription_id, resource_group_name, testcontainer)
+    @test haskey(result, "Blobs")
+    @test haskey(result["Blobs"], "Blob")
+    blobs = result["Blobs"]["Blob"]
+    @test length(blobs) == 2
+    blobnames = Set(b["Name"] for b in blobs)
+    @test "testblob1" in blobnames
+    @test "testblob2" in blobnames
+
+    blobbytes1 = getBlob(ctx, subscription_id, resource_group_name, testblob1)
+    @test String(blobbytes1) == "hello world"
+
+    blobbytes2 = getBlob(ctx, subscription_id, resource_group_name, testblob2)
+    blobstr2 = String(blobbytes2)
+    @test strip(blobstr2) == "hello world"
+    @test length(blobstr2) > length("hello world")
+
+    # delete blobs
+    @test deleteBlob(ctx, subscription_id, resource_group_name, testblob1)
+    @test deleteBlob(ctx, subscription_id, resource_group_name, testblob2)
+
+    @test deleteContainer(ctx, subscription_id, resource_group_name, testcontainer)
+end


### PR DESCRIPTION
This implements some more APIs for Azure blob store, using the Azure REST API service. These are the blob store APIs supported now:

- listContainers
- createContainer
- deleteContainer
- listBlobs
- putBlob (BlockBlobs only)
- getBlob
- deleteBlob